### PR TITLE
increment version for IPy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 geoip2==3.0.0
 geohash2==1.1
 influxdb==5.3.0
-IPy==1.0
+IPy==1.01


### PR DESCRIPTION
to support python 3.10+
discussed in discord https://discord.com/channels/354974912613449730/1067530685096661043
1.01 has a janky fix ([my PR](https://github.com/autocracy/python-ipy/pull/80) to IPy should go into 1.02 ) but i think it should work